### PR TITLE
Use correct mountpoint for configmap

### DIFF
--- a/src/main/fabric8/deployment.yml
+++ b/src/main/fabric8/deployment.yml
@@ -15,4 +15,4 @@ spec:
       containers:
         - volumeMounts:
             - name: config
-              mountPath: /app/config
+              mountPath: /deployments/config


### PR DESCRIPTION
@jstrachan Volume mount point has to be /deployments/config as /deployments is the working directory in the image. See http://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-external-config.html#boot-features-external-config-application-property-files for locations searched for application.properties.